### PR TITLE
ログイン時のログ出力数をコマンドライン引数により設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+db/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 socket.io を使ったチャットアプリケーションです。
 
+## 必要なモジュール
+
+ログの格納に__NeDB__モジュールを利用します。  
+https://github.com/louischatriot/nedb  
+
+ログ記録/読込時にタイムスタンプを利用するため__Date-Utils__モジュールを利用します。  
+https://github.com/JerrySievert/date-utils/
+
+コマンドライン引数の処理に__argv__モジュールを利用します。  
+https://www.npmjs.com/package/argv
+
 ## 使い方
 
 サーバーの起動:
@@ -13,3 +24,19 @@ $ nodejs server.js
 ```
 $ nodejs client.js
 ```
+
+ログイン時に出力されるログの最大数を設定する場合:
+
+```
+$ nodejs client.ls -l value
+```
+デフォルトでは15件です。  
+
+## ログの出力形式
+
+```
+[ MM/DD HH24:MI ]user: message_...
+[ MM/DD HH24:MI ]user: message_before_last
+[ MM/DD HH24:MI ]user: message_last
+```
+

--- a/client.js
+++ b/client.js
@@ -78,7 +78,7 @@ socket.on('show_log', function(data) {
 
 var args = argv.run();
 var max_output_log = 15;
-if(args.options.log != undefined){
+if(typeof args.options.log !== 'undefined'){
     max_output_log = args.options.log;
 }
 askUserName();

--- a/client.js
+++ b/client.js
@@ -1,6 +1,18 @@
 var io = require('socket.io-client');
 var socket = io('http://localhost:3000');
+var argv = require( 'argv' );
 var readline = require('readline');
+
+//コマンドラインオプションを定義
+argv.option([
+    {
+    name: 'log',
+    short: 'l',
+    type: 'int',
+    description: 'ログイン時に表示されるログ数を指定します',
+    example: '"node client.js log --log=balue" or "node client.js -l value"'
+    },
+]);
 
 var rl = readline.createInterface({
     input: process.stdin,
@@ -16,7 +28,7 @@ function askUserName() {
     rl.prompt();
     
     rl.once('line', function(line) {
-        socket.emit('user login', line.trim());
+        socket.emit('user login', line.trim(), max_output_log);
     });
 }
 
@@ -60,4 +72,13 @@ socket.on('say', function(data) {
     log('%s: %s', data.name, data.message);
 });
 
+socket.on('show_log', function(data) {
+    log('[ %s ] %s: %s', data.date, data.name, data.message);
+});
+
+var args = argv.run();
+var max_output_log = 15;
+if(args.options.log != undefined){
+    max_output_log = args.options.log;
+}
 askUserName();

--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
 var io = require('socket.io-client');
 var socket = io('http://localhost:3000');
-var argv = require( 'argv' );
+var argv = require('argv');
 var readline = require('readline');
 
 //コマンドラインオプションを定義

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "socket.io-chat",
   "version": "0.0.0",
   "dependencies": {
-    "socket.io": "~1.4.8",
+    "argv": "0.0.2",
+    "date-utils": "^1.2.21",
+    "nedb": "^1.8.0",
+    "socket.io": "^1.4.8",
     "socket.io-client": "~1.4.8"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,10 @@
 var io = require('socket.io')();
+var DateUtil = require('date-utils');
+var Database = require("nedb");
+var db = new Database({
+    filename: "./db/chat_log",
+    autoload: true
+});
 var users = {}
 
 io.on('connection', function(client){
@@ -6,12 +12,23 @@ io.on('connection', function(client){
 
     client.loggedIn = false;
 
-    client.on('user login', function(name) {
+    client.on('user login', function(name, max_output_log) {
         if (!(name in users)) {
             console.log('%s user login as "%s"', client.id, name);
 
             client.loggedIn = true;
-            client.emit('login', users);
+
+	    // タイムスタンプ降順でDBからログを取得
+	    // ログインユーザの画面へ取得したログを昇順に表示させる
+	    db.find().sort({'date': -1 }).limit(max_output_log).exec(function (err, LOG) {
+		LOG.reverse();
+ 		for(var i in LOG){
+		    var timestamp = LOG[i].date.toFormat("MM/DD HH24:MI");
+ 		    client.emit('show_log', {message: LOG[i].message, name: LOG[i].name, date: timestamp});
+		}
+	    });
+
+            client.emit('login', users); 
 
             users[name] = client.id;
             client.broadcast.emit('user enter', name);
@@ -29,13 +46,22 @@ io.on('connection', function(client){
         }
 
         console.log('%s user say: "%s"', client.id, msg);
-
         var n = '';
         for (var k in users) {
             if (users[k] == client.id) {
                 n = k;
             }
         }
+	// タイムスタンプを取得
+	var dt = new Date();
+	// nとmsgとdtをDBに格納
+	var doc = {
+	     name: n,
+	     message: msg,
+	     date: dt
+	};
+	db.insert(doc); 
+
         io.emit('say', {message: msg, name: n});
     });
 


### PR DESCRIPTION
## 概要
前回のfeature/show_15logsブランチを誤ってmasterブランチにマージしてしまったため、  

1. masterブランチのマージコミットをrevert  
2. feature/show_15logsブランチにmasterブランチを一旦マージ  
3. feature/show_15logsブランチを、masterブランチにマージする前の状態まで復元  
4. push後、再度プルリクエストを送信  
という形で対応しました  

参考: http://qiita.com/bigplants@github/items/3d1d3ada97d0c86d2548

## 変更点
・言及のあったtypo及び不要なコメントを修正/削除  
・依存関係の解決  
・タイムスタンプをDate型のまま格納  
・ログ出力時にタイムスタンプも出力  
・ログ出力数の設定をするコマンドラインオプション(-l)の実装  